### PR TITLE
Improves spec compliance: primitive.mode is optional

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1317,7 +1317,7 @@ GLTFParser.prototype.loadMeshes = function() {
 
 			_each( primitives, function( primitive ) {
 
-				if ( primitive.mode === WEBGL_CONSTANTS.TRIANGLES ) {
+				if ( primitive.mode === WEBGL_CONSTANTS.TRIANGLES || primitive.mode === undefined ) {
 
 					var geometry = new THREE.BufferGeometry();
 


### PR DESCRIPTION
[As per the specification](https://github.com/KhronosGroup/glTF/blob/master/specification/README.md#primitivemode), `primitive.mode` is optional and `TRIANGLES` should be assumed if it's missing.
